### PR TITLE
Cloog Compatability Fix

### DIFF
--- a/scripts/global.sh
+++ b/scripts/global.sh
@@ -2,7 +2,7 @@ export GMP_VERSION=6.1.2
 export MPFR_VERSION=4.0.1
 export MPC_VERSION=1.1.0
 export ISL_VERSION=0.19
-export CLOOG_VERSION=0.18.4
+export CLOOG_VERSION=0.19.0
 export BINUTILS_VERSION=2.30
 export GCC_VERSION=8.1.0
 export GDB_VERSION=8.1
@@ -18,7 +18,7 @@ export GRUB_VERSION=2.02
 
 export GNU_MIRROR_BASE=https://ftp.gnu.org/gnu
 export ISL_MIRROR_BASE=http://isl.gforge.inria.fr
-export CLOOG_MIRROR_BASE=https://www.bastoul.net/cloog/pages/download
+export CLOOG_MIRROR_BASE=https://github.com/periscop/cloog/releases/download
 export PKG_CONFIG_MIRROR_BASE=https://pkg-config.freedesktop.org/releases
 export LIBFFI_MIRROR_BASE=http://sourceware.org/pub/libffi
 export PCRE_MIRROR_BASE=https://ftp.pcre.org/pub/pcre
@@ -32,8 +32,10 @@ export PATH=$INSTALL_DIR/bin:$PATH
 function download_compile {
 	echo $1
 	rm -rf $2*
-	curl $1 > $2.archive
+
+	curl $1 -L > $2.archive
 	tar -xf $2.archive
+	
 	mkdir $2-build
 	cd $2-build
 

--- a/scripts/global.sh
+++ b/scripts/global.sh
@@ -2,7 +2,7 @@ export GMP_VERSION=6.1.2
 export MPFR_VERSION=4.0.1
 export MPC_VERSION=1.1.0
 export ISL_VERSION=0.19
-export CLOOG_VERSION=0.19.0
+export CLOOG_VERSION=0.18.4
 export BINUTILS_VERSION=2.30
 export GCC_VERSION=8.1.0
 export GDB_VERSION=8.1
@@ -18,7 +18,7 @@ export GRUB_VERSION=2.02
 
 export GNU_MIRROR_BASE=https://ftp.gnu.org/gnu
 export ISL_MIRROR_BASE=http://isl.gforge.inria.fr
-export CLOOG_MIRROR_BASE=https://github.com/periscop/cloog/releases/download
+export CLOOG_MIRROR_BASE=https://www.bastoul.net/cloog/pages/download
 export PKG_CONFIG_MIRROR_BASE=https://pkg-config.freedesktop.org/releases
 export LIBFFI_MIRROR_BASE=http://sourceware.org/pub/libffi
 export PCRE_MIRROR_BASE=https://ftp.pcre.org/pub/pcre
@@ -32,10 +32,8 @@ export PATH=$INSTALL_DIR/bin:$PATH
 function download_compile {
 	echo $1
 	rm -rf $2*
-
-	curl $1 -L > $2.archive
+	curl $1 > $2.archive
 	tar -xf $2.archive
-	
 	mkdir $2-build
 	cd $2-build
 

--- a/scripts/toolchain-i686.sh
+++ b/scripts/toolchain-i686.sh
@@ -4,6 +4,6 @@ download_compile $GNU_MIRROR_BASE/gmp/gmp-$GMP_VERSION.tar.bz2 gmp-$GMP_VERSION
 download_compile $GNU_MIRROR_BASE/mpfr/mpfr-$MPFR_VERSION.tar.bz2 mpfr-$MPFR_VERSION "--with-gmp=$INSTALL_DIR"
 download_compile $GNU_MIRROR_BASE/mpc/mpc-$MPC_VERSION.tar.gz mpc-$MPC_VERSION "--with-gmp=$INSTALL_DIR --with-mpfr=$INSTALL_DIR"
 download_compile $ISL_MIRROR_BASE/isl-$ISL_VERSION.tar.gz isl-$ISL_VERSION "--with-gmp-prefix=$INSTALL_DIR"
-download_compile $CLOOG_MIRROR_BASE/cloog-$CLOOG_VERSION.tar.gz cloog-$CLOOG_VERSION "--with-gmp-prefix=$INSTALL_DIR --with-isl-prefix=$INSTALL_DIR"
+download_compile $CLOOG_MIRROR_BASE/cloog-$CLOOG_VERSION/cloog-$CLOOG_VERSION.tar.gz cloog-$CLOOG_VERSION "--with-gmp-prefix=$INSTALL_DIR --with-isl-prefix=$INSTALL_DIR"
 download_compile $GNU_MIRROR_BASE/binutils/binutils-$BINUTILS_VERSION.tar.gz binutils-$BINUTILS_VERSION "--with-isl=$INSTALL_DIR --with-cloog=$INSTALL_DIR --with-sysroot --disable-nls --disable-werror --target=i686-elf"
 download_compile $GNU_MIRROR_BASE/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.gz gcc-$GCC_VERSION "--with-isl=$INSTALL_DIR --with-cloog=$INSTALL_DIR --with-gmp=$INSTALL_DIR --with-mpfr=$INSTALL_DIR --with-mpc=$INSTALL_DIR --disable-nls --enable-languages=c,c++ --without-headers --target=i686-elf"

--- a/scripts/toolchain-i686.sh
+++ b/scripts/toolchain-i686.sh
@@ -4,6 +4,6 @@ download_compile $GNU_MIRROR_BASE/gmp/gmp-$GMP_VERSION.tar.bz2 gmp-$GMP_VERSION
 download_compile $GNU_MIRROR_BASE/mpfr/mpfr-$MPFR_VERSION.tar.bz2 mpfr-$MPFR_VERSION "--with-gmp=$INSTALL_DIR"
 download_compile $GNU_MIRROR_BASE/mpc/mpc-$MPC_VERSION.tar.gz mpc-$MPC_VERSION "--with-gmp=$INSTALL_DIR --with-mpfr=$INSTALL_DIR"
 download_compile $ISL_MIRROR_BASE/isl-$ISL_VERSION.tar.gz isl-$ISL_VERSION "--with-gmp-prefix=$INSTALL_DIR"
-download_compile $CLOOG_MIRROR_BASE/cloog-$CLOOG_VERSION/cloog-$CLOOG_VERSION.tar.gz cloog-$CLOOG_VERSION "--with-gmp-prefix=$INSTALL_DIR --with-isl-prefix=$INSTALL_DIR"
+download_compile $CLOOG_MIRROR_BASE/cloog-$CLOOG_VERSION.tar.gz cloog-$CLOOG_VERSION "--with-gmp-prefix=$INSTALL_DIR --with-isl-prefix=$INSTALL_DIR"
 download_compile $GNU_MIRROR_BASE/binutils/binutils-$BINUTILS_VERSION.tar.gz binutils-$BINUTILS_VERSION "--with-isl=$INSTALL_DIR --with-cloog=$INSTALL_DIR --with-sysroot --disable-nls --disable-werror --target=i686-elf"
 download_compile $GNU_MIRROR_BASE/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.gz gcc-$GCC_VERSION "--with-isl=$INSTALL_DIR --with-cloog=$INSTALL_DIR --with-gmp=$INSTALL_DIR --with-mpfr=$INSTALL_DIR --with-mpc=$INSTALL_DIR --disable-nls --enable-languages=c,c++ --without-headers --target=i686-elf"


### PR DESCRIPTION
Included scripts that created a GCC cross-compiler for SydOS did not work because Cloog 0.18.4 was incompatable with never versions of he other dependencies. I found a patch and applied it to the scripts. It is not an official Cloog repository, which is something to keep in mind, but it does compile SydOS perfectly.